### PR TITLE
Misleading message during configuration.

### DIFF
--- a/setup/views.py
+++ b/setup/views.py
@@ -77,7 +77,7 @@ def covername(request):
         if PDB['covername'] is not None:
                 return redirect('setup.gpg')
         if not TTU.query_daemon_states('tor'):
-                return please_wait(request, caption='drive encryption')
+                return please_wait(request, caption='We are waiting for tor to be alive')
         template = loader.get_template('setup.dtl')
         context = RequestContext(request, {
                 'title':'Covername selection',


### PR DESCRIPTION
The block of code is entered if the tor service is not running, instead
the message talks about drive encryption that is not the issue here.